### PR TITLE
plot image for D2L Java

### DIFF
--- a/build_html.sh
+++ b/build_html.sh
@@ -3,6 +3,9 @@
 # build_html.sh
 # build website based on jupyter notebooks
 
+# ask tablesaw to plot <img> for Sphinx to load
+export D2L_PLOT_IMAGE=1
+
 echo "Try to fetch daily backup"
 date=$(date '+%Y-%m-%d')
 aws s3 sync s3://d2l-java-notebook/daily-backup/$date .

--- a/utils/plot-utils.ipynb
+++ b/utils/plot-utils.ipynb
@@ -69,23 +69,6 @@
     "import tech.tablesaw.plotly.components.*;\n",
     "import tech.tablesaw.plotly.traces.*;"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "double[] x = {1, 2, 3, 4, 5, 6};\n",
-    "double[] y = {0, 1, 6, 14, 25, 39};\n",
-    "String[] labels = {\"a\", \"b\", \"c\", \"d\", \"e\", \"f\"};\n",
-    "\n",
-    "ScatterTrace trace = ScatterTrace.builder(x, y)\n",
-    "        .text(labels)\n",
-    "        .build();\n",
-    "\n",
-    "render(new Figure(trace));"
-   ]
   }
  ],
  "metadata": {

--- a/utils/plot-utils.ipynb
+++ b/utils/plot-utils.ipynb
@@ -29,20 +29,32 @@
     "    .register((figure, ctx) -> {\n",
     "        ctx.renderIfRequested(io.github.spencerpark.jupyter.kernel.display.mime.MIMEType.TEXT_HTML, () -> {\n",
     "            String id = UUID.randomUUID().toString().replace(\"-\", \"\");\n",
-    "            \n",
+    "            boolean plotImage = System.getenv().containsKey(\"D2L_PLOT_IMAGE\");\n",
+    "\n",
     "            figure.asJavascript(id);\n",
     "            Map<String, Object> context = figure.getContext();\n",
-    "            \n",
     "            StringBuilder html = new StringBuilder();\n",
+    "            html.append(\"<img id=\\\"\").append(id).append(\"-img\\\"></img>\\n\");\n",
     "            html.append(\"<div id=\\\"\").append(id).append(\"\\\"></div>\\n\");\n",
-    "            html.append(\"<script>require(['https://cdn.plot.ly/plotly-1.44.4.min.js'], Plotly => {\\n\");\n",
-    "            html.append(\"var target_\").append(id).append(\" = document.getElementById('\").append(id).append(\"');\\n\");\n",
+    "            html.append(\"<script>require(['https://cdn.plot.ly/plotly-1.57.0.min.js'], Plotly => {\\n\");\n",
+    "            if (!plotImage) {\n",
+    "                // render javascript\n",
+    "                html.append(\"var \").append(context.get(\"targetName\")).append(\" = document.getElementById('\").append(id).append(\"');\\n\");\n",
+    "            } else {\n",
+    "                // render image\n",
+    "                html.append(\"var \").append(context.get(\"targetName\")).append(\" = document.createElement(\\\"div\\\");\\n\");\n",
+    "                html.append(\"var d3 = Plotly.d3;\\n\");\n",
+    "                html.append(\"var img_jpg= d3.select(\\\"#\").append(id).append(\"-img\\\");\\n\");\n",
+    "                String plotFunction = (String) context.get(\"plotFunction\");\n",
+    "                String imgExt = \".then(function(gd) { Plotly.toImage(gd).then(function(url) { img_jpg.attr(\\\"src\\\", url); } )});\";\n",
+    "                context.put(\"plotFunction\", plotFunction.substring(0, plotFunction.length() - 1) + imgExt);\n",
+    "            }\n",
     "            html.append(context.get(\"figure\")).append('\\n');\n",
     "            html.append(context.get(\"plotFunction\")).append('\\n');\n",
     "            html.append(\"})</script>\\n\");\n",
     "            return html.toString();\n",
-    "        });\n",
-    "    });"
+    "    });\n",
+    "});"
    ]
   },
   {
@@ -54,7 +66,25 @@
     "import tech.tablesaw.api.*;\n",
     "import tech.tablesaw.plotly.*;\n",
     "import tech.tablesaw.plotly.api.*;\n",
-    "import tech.tablesaw.plotly.components.*;"
+    "import tech.tablesaw.plotly.components.*;\n",
+    "import tech.tablesaw.plotly.traces.*;"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "double[] x = {1, 2, 3, 4, 5, 6};\n",
+    "double[] y = {0, 1, 6, 14, 25, 39};\n",
+    "String[] labels = {\"a\", \"b\", \"c\", \"d\", \"e\", \"f\"};\n",
+    "\n",
+    "ScatterTrace trace = ScatterTrace.builder(x, y)\n",
+    "        .text(labels)\n",
+    "        .build();\n",
+    "\n",
+    "render(new Figure(trace));"
    ]
   }
  ],
@@ -70,7 +100,7 @@
    "mimetype": "text/x-java-source",
    "name": "Java",
    "pygments_lexer": "java",
-   "version": "12.0.2+10"
+   "version": "11.0.5+10-LTS"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Add plot image option for D2L Java notebook.

You can do that by setting Env:

```
export D2L_PLOT_IMAGE=1
```
And all images are rendered into base64 encoding without javascript