### PR TITLE
allow javascript dynamic loading

### DIFF
--- a/build_html.sh
+++ b/build_html.sh
@@ -4,7 +4,7 @@
 # build website based on jupyter notebooks
 
 # ask tablesaw to plot <img> for Sphinx to load
-export D2L_PLOT_IMAGE=1
+# export D2L_PLOT_IMAGE=1
 
 echo "Try to fetch daily backup"
 date=$(date '+%Y-%m-%d')

--- a/config.ini
+++ b/config.ini
@@ -56,6 +56,8 @@ favicon = static/favicon.png
 
 html_logo = static/logo-with-text.png
 
+# A list of JS files to be included
+include_js = https://cdnjs.cloudflare.com/ajax/libs/require.js/2.3.6/require.min.js
 
 [pdf]
 


### PR DESCRIPTION
When building sphinx docs, the require.min.js (came from node.js) are not included. This can be applied for dynamic generation on the javascript content.

Try to load from CDN when we build on the website to use this CSS for JavaScript feature