### PR TITLE
fix typo and function call style of sum

### DIFF
--- a/chapter_linear-networks/softmax-regression-scratch.ipynb
+++ b/chapter_linear-networks/softmax-regression-scratch.ipynb
@@ -70,7 +70,7 @@
    "metadata": {},
    "source": [
     "We will work with the Fashion-MNIST dataset, just introduced in :numref:`sec_fashion_mnist`,\n",
-    "setting up an iterator with batch size $256$. We also set it to randomly shuffle elements for each batch for the training set. "
+    "setting up an iterator with batch size $256$. We also set it to randomly shuffled elements for each batch for the training set. "
    ]
   },
   {
@@ -155,11 +155,11 @@
     "We wrap the axis in an int array since we can specify multiple axes as well.\n",
     "For example if we call `sum()` with `new int[]{0, 1}`, it sums up the elements over both the rows and columns.\n",
     "In this 2D array, this means the total sum of the elements within! \n",
-    "Note that if `X` is an array with shape `(2, 3)`\n",
-    "and we sum over the columns (`X.sum(axis=0)`),\n",
-    "the result will be a (1D) vector with shape `(3,)`.\n",
+    "Note that if `X` is an array with shape `($2$, $3$)`\n",
+    "and we sum over the columns (`X.sum(new int[]{0})`),\n",
+    "the result will be a (1D) vector with shape `($3$,)`.\n",
     "If we want to keep the number of axes in the original array\n",
-    "(resulting in a 2D array with shape `(1, 3)`),\n",
+    "(resulting in a 2D array with shape `($1$, $3$)`),\n",
     "rather than collapsing out the dimension that we summed over\n",
     "we can specify `true` when invoking `sum()`."
    ]
@@ -407,7 +407,7 @@
     "The result has the same shape as the variable `y`.\n",
     "Now we just need to check how frequently the two match.\n",
     "Since the equality function `eq()` is datatype-sensitive\n",
-    "(e.g., an `float32` and a `float32` are never equal),\n",
+    "(e.g., a `float32` and a `float32` are never equal),\n",
     "we also need to convert both to the same type (we pick `int32`).\n",
     "The result is an `NDArray` containing entries of 0 (false) and 1 (true).\n",
     "We then sum the number of true entries and convert the result to a float.\n",
@@ -783,7 +783,7 @@
     "In practice we will want to split our data three ways\n",
     "into training, validation, and test data,\n",
     "using the validation data to choose\n",
-    "the best values of our hyperparameters."
+    "the best values of our hyper-parameters."
    ]
   },
   {


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

- shuffle -> shuffled, to make this sentence clearer
- `X.sum(axis=0)` is python style function call, change to `X.sum(new int[]{0})`
- an `float32` -> **a** `float32`
- `(2, 3)` -> `($2$, $3$)`

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
