### PR TITLE
Replace 10.0 snapshot with release

### DIFF
--- a/chapter_linear-networks/image-classification-dataset.ipynb
+++ b/chapter_linear-networks/image-classification-dataset.ipynb
@@ -32,12 +32,12 @@
    "source": [
     "%mavenRepo snapshots https://oss.sonatype.org/content/repositories/snapshots/\n",
     "\n",
-    "%maven ai.djl:api:0.10.0-SNAPSHOT\n",
+    "%maven ai.djl:api:0.10.0\n",
     "%maven ai.djl:basicdataset:0.8.0\n",
     "%maven org.slf4j:slf4j-api:1.7.26\n",
     "%maven org.slf4j:slf4j-simple:1.7.26\n",
     "    \n",
-    "%maven ai.djl.mxnet:mxnet-engine:0.10.0-SNAPSHOT\n",
+    "%maven ai.djl.mxnet:mxnet-engine:0.10.0\n",
     "%maven ai.djl.mxnet:mxnet-native-auto:1.7.0-backport"
    ]
   },

--- a/chapter_linear-networks/linear-regression-djl.ipynb
+++ b/chapter_linear-networks/linear-regression-djl.ipynb
@@ -36,13 +36,13 @@
    "source": [
     "%mavenRepo snapshots https://oss.sonatype.org/content/repositories/snapshots/\n",
     "\n",
-    "%maven ai.djl:api:0.10.0-SNAPSHOT\n",
+    "%maven ai.djl:api:0.10.0\n",
     "%maven ai.djl:model-zoo:0.8.0\n",
     "%maven org.slf4j:slf4j-api:1.7.26\n",
     "%maven org.slf4j:slf4j-simple:1.7.26\n",
     "%maven net.java.dev.jna:jna:5.3.0\n",
     "    \n",
-    "%maven ai.djl.mxnet:mxnet-engine:0.10.0-SNAPSHOT\n",
+    "%maven ai.djl.mxnet:mxnet-engine:0.10.0\n",
     "%maven ai.djl.mxnet:mxnet-native-auto:1.7.0-b"
    ]
   },

--- a/chapter_linear-networks/linear-regression-scratch.ipynb
+++ b/chapter_linear-networks/linear-regression-scratch.ipynb
@@ -38,11 +38,11 @@
    "source": [
     "%mavenRepo snapshots https://oss.sonatype.org/content/repositories/snapshots/\n",
     "\n",
-    "%maven ai.djl:api:0.10.0-SNAPSHOT\n",
+    "%maven ai.djl:api:0.10.0\n",
     "%maven org.slf4j:slf4j-api:1.7.26\n",
     "%maven org.slf4j:slf4j-simple:1.7.26\n",
     "\n",
-    "%maven ai.djl.mxnet:mxnet-engine:0.10.0-SNAPSHOT\n",
+    "%maven ai.djl.mxnet:mxnet-engine:0.10.0\n",
     "%maven ai.djl.mxnet:mxnet-native-auto:1.7.0-backport"
    ]
   },

--- a/chapter_linear-networks/linear-regression.ipynb
+++ b/chapter_linear-networks/linear-regression.ipynb
@@ -358,13 +358,13 @@
    "source": [
     "%mavenRepo snapshots https://oss.sonatype.org/content/repositories/snapshots/\n",
     "\n",
-    "%maven ai.djl:api:0.10.0-SNAPSHOT\n",
+    "%maven ai.djl:api:0.10.0\n",
     "%maven org.slf4j:slf4j-api:1.7.26\n",
     "%maven org.slf4j:slf4j-simple:1.7.26\n",
     "\n",
     "// See https://github.com/awslabs/djl/blob/master/mxnet/mxnet-engine/README.md\n",
     "// for more MXNet library selection options\n",
-    "%maven ai.djl.mxnet:mxnet-engine:0.10.0-SNAPSHOT \n",
+    "%maven ai.djl.mxnet:mxnet-engine:0.10.0 \n",
     "%maven ai.djl.mxnet:mxnet-native-auto:1.7.0-backport"
    ]
   },

--- a/chapter_linear-networks/softmax-regression-djl.ipynb
+++ b/chapter_linear-networks/softmax-regression-djl.ipynb
@@ -28,12 +28,12 @@
    "source": [
     "%mavenRepo snapshots https://oss.sonatype.org/content/repositories/snapshots/\n",
     "\n",
-    "%maven ai.djl:api:0.10.0-SNAPSHOT\n",
+    "%maven ai.djl:api:0.10.0\n",
     "%maven ai.djl:basicdataset:0.8.0\n",
     "%maven org.slf4j:slf4j-api:1.7.26\n",
     "%maven org.slf4j:slf4j-simple:1.7.26\n",
     "    \n",
-    "%maven ai.djl.mxnet:mxnet-engine:0.10.0-SNAPSHOT\n",
+    "%maven ai.djl.mxnet:mxnet-engine:0.10.0\n",
     "%maven ai.djl.mxnet:mxnet-native-auto:1.7.0-backport"
    ]
   },

--- a/chapter_linear-networks/softmax-regression-scratch.ipynb
+++ b/chapter_linear-networks/softmax-regression-scratch.ipynb
@@ -30,12 +30,12 @@
    "source": [
     "%mavenRepo snapshots https://oss.sonatype.org/content/repositories/snapshots/\n",
     "\n",
-    "%maven ai.djl:api:0.10.0-SNAPSHOT\n",
+    "%maven ai.djl:api:0.10.0\n",
     "%maven ai.djl:basicdataset:0.8.0\n",
     "%maven org.slf4j:slf4j-api:1.7.26\n",
     "%maven org.slf4j:slf4j-simple:1.7.26\n",
     "    \n",
-    "%maven ai.djl.mxnet:mxnet-engine:0.10.0-SNAPSHOT\n",
+    "%maven ai.djl.mxnet:mxnet-engine:0.10.0\n",
     "%maven ai.djl.mxnet:mxnet-native-auto:1.7.0-backport"
    ]
   },

--- a/chapter_preliminaries/autograd.ipynb
+++ b/chapter_preliminaries/autograd.ipynb
@@ -36,11 +36,11 @@
    "source": [
     "%mavenRepo snapshots https://oss.sonatype.org/content/repositories/snapshots/\n",
     "\n",
-    "%maven ai.djl:api:0.10.0-SNAPSHOT\n",
+    "%maven ai.djl:api:0.10.0\n",
     "%maven org.slf4j:slf4j-api:1.7.26\n",
     "%maven org.slf4j:slf4j-simple:1.7.26\n",
     "\n",
-    "%maven ai.djl.mxnet:mxnet-engine:0.10.0-SNAPSHOT\n",
+    "%maven ai.djl.mxnet:mxnet-engine:0.10.0\n",
     "%maven ai.djl.mxnet:mxnet-native-auto:1.7.0-backport"
    ]
   },

--- a/chapter_recurrent-neural-networks/language-models-and-dataset.ipynb
+++ b/chapter_recurrent-neural-networks/language-models-and-dataset.ipynb
@@ -142,11 +142,11 @@
    "source": [
     "%mavenRepo snapshots https://oss.sonatype.org/content/repositories/snapshots/\n",
     "\n",
-    "%maven ai.djl:api:0.10.0-SNAPSHOT\n",
+    "%maven ai.djl:api:0.10.0\n",
     "%maven org.slf4j:slf4j-api:1.7.26\n",
     "%maven org.slf4j:slf4j-simple:1.7.26\n",
     "\n",
-    "%maven ai.djl.mxnet:mxnet-engine:0.10.0-SNAPSHOT\n",
+    "%maven ai.djl.mxnet:mxnet-engine:0.10.0\n",
     "%maven ai.djl.mxnet:mxnet-native-auto:1.7.0-backport"
    ]
   },

--- a/chapter_recurrent-neural-networks/rnn.ipynb
+++ b/chapter_recurrent-neural-networks/rnn.ipynb
@@ -147,11 +147,11 @@
    "source": [
     "%mavenRepo snapshots https://oss.sonatype.org/content/repositories/snapshots/\n",
     "\n",
-    "%maven ai.djl:api:0.10.0-SNAPSHOT\n",
+    "%maven ai.djl:api:0.10.0\n",
     "%maven org.slf4j:slf4j-api:1.7.26\n",
     "%maven org.slf4j:slf4j-simple:1.7.26\n",
     "\n",
-    "%maven ai.djl.mxnet:mxnet-engine:0.10.0-SNAPSHOT\n",
+    "%maven ai.djl.mxnet:mxnet-engine:0.10.0\n",
     "%maven ai.djl.mxnet:mxnet-native-auto:1.7.0-backport"
    ]
   },

--- a/chapter_recurrent-neural-networks/sequence.ipynb
+++ b/chapter_recurrent-neural-networks/sequence.ipynb
@@ -115,11 +115,11 @@
    "source": [
     "%mavenRepo snapshots https://oss.sonatype.org/content/repositories/snapshots/\n",
     "\n",
-    "%maven ai.djl:api:0.10.0-SNAPSHOT\n",
+    "%maven ai.djl:api:0.10.0\n",
     "%maven org.slf4j:slf4j-api:1.7.26\n",
     "%maven org.slf4j:slf4j-simple:1.7.26\n",
     "\n",
-    "%maven ai.djl.mxnet:mxnet-engine:0.10.0-SNAPSHOT\n",
+    "%maven ai.djl.mxnet:mxnet-engine:0.10.0\n",
     "%maven ai.djl.mxnet:mxnet-native-auto:1.7.0-backport"
    ]
   },

--- a/chapter_recurrent-neural-networks/text-preprocessing.ipynb
+++ b/chapter_recurrent-neural-networks/text-preprocessing.ipynb
@@ -40,7 +40,7 @@
    "source": [
     "%mavenRepo snapshots https://oss.sonatype.org/content/repositories/snapshots/\n",
     "\n",
-    "%maven ai.djl:api:0.10.0-SNAPSHOT"
+    "%maven ai.djl:api:0.10.0"
    ]
   },
   {


### PR DESCRIPTION
This should fix the CI as the 10.0 snapshot is no longer available

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
