### PR TITLE
Updating RNN notebook to include `setRequiresGradient` instead of `attachGradient`

### DIFF
--- a/chapter_recurrent-neural-networks/rnn-scratch.ipynb
+++ b/chapter_recurrent-neural-networks/rnn-scratch.ipynb
@@ -226,7 +226,7 @@
     "    // Attach gradients\n",
     "    NDList params = new NDList(W_xh, W_hh, b_h, W_hq, b_q);\n",
     "    for (NDArray param : params) {\n",
-    "        param.attachGradient();\n",
+    "        param.setRequiresGradient(true);\n",
     "    }\n",
     "    return params;\n",
     "}\n",


### PR DESCRIPTION
Changing `attachGradient()` to `setRequiresGradient()` based on 0.11.0 update. Fixes error when running notebook as `attachGradient()` is not included in DJL anymore.